### PR TITLE
remove BOM header from package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
-﻿{
+{
     "name": "laypage",
     "version": "1.3.0",
     "description": "分页组件",
@@ -17,6 +17,6 @@
         "grunt-contrib-uglify": "*",
         "grunt-contrib-cssmin": "*",
         "grunt-css": "*"
-        
+
     }
 }


### PR DESCRIPTION
NPM will throw an error when encounter a file with BOM header, so I strip the BOM header.

The following is the diff:
diff --git a/package.json b/package.json
index 9b5fe71..75bfbad 100644
--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
-<U+FEFF>{
+{
     "name": "laypage",
     "version": "1.3.0",
     "description": "分页组件",
@@ -17,6 +17,6 @@
         "grunt-contrib-uglify": "*",
         "grunt-contrib-cssmin": "*",
         "grunt-css": "*"
-
+
     }
 }